### PR TITLE
add 0-Clause BSD NON-AI License

### DIFF
--- a/NON-AI-BSD0
+++ b/NON-AI-BSD0
@@ -1,0 +1,23 @@
+0-Clause BSD NON-AI License
+
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted, subject to the following
+condition:
+
+1. The software shall not be used, directly or indirectly, for any purpose
+   related to artificial intelligence training, machine learning, or the
+   creation of datasets intended for use in artificial intelligence or
+   machine learning applications, including but not limited to code generation,
+   text generation, tokenization, natural language processing,
+   data mining and predictive analytics.
+
+Any violation of this condition shall be considered a breach of this
+License and will result in the termination of the rights granted herein.
+
+THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE
+FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
Learned of this license recently. It's pretty good in a sense that it's essentially public domain, but without words "public domain", meaning of which differ from jurisdiction to jurisdiction. Should make a better alternative to Unlicense for European users.

